### PR TITLE
Add docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ To build and run with Docker:
 docker build -t secure-tinydb-app .
 docker run -p 8000:8000 secure-tinydb-app
 ```
+
+## Docker Compose
+
+To start the application with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+The compose file loads variables from `.env` and persists the database and uploaded images in the current directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    env_file:
+      - .env
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./db.json:/app/db.json
+      - ./static/images:/app/static/images


### PR DESCRIPTION
## Summary
- add docker-compose.yml for running the FastAPI service
- document how to run with Docker Compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686ccf1369248325a95f450114a6e854